### PR TITLE
Switching *sql.DB to local DB interface

### DIFF
--- a/sqlitestore.go
+++ b/sqlitestore.go
@@ -141,7 +141,6 @@ func (m *SqliteStore) New(r *http.Request, name string) (*sessions.Session, erro
 		if err == nil {
 			err = m.load(session)
 			if err == nil {
-				fmt.Println(err)
 				session.IsNew = false
 			} else {
 				err = nil


### PR DESCRIPTION
This allows the use of a different db adapter, such as [sqlx](https://github.com/jmoiron/sqlx) when creating the session store from an existing open connection.