### PR TITLE
Add MaxLength

### DIFF
--- a/sqlitestore.go
+++ b/sqlitestore.go
@@ -223,7 +223,7 @@ func (m *SqliteStore) Delete(r *http.Request, w http.ResponseWriter, session *se
 }
 
 func (m *SqliteStore) save(session *sessions.Session) error {
-	if session.IsNew == true {
+	if session.IsNew {
 		return m.insert(session)
 	}
 	var createdOn time.Time
@@ -267,9 +267,9 @@ func (m *SqliteStore) load(session *sessions.Session) error {
 	if scanErr != nil {
 		return scanErr
 	}
-	if sess.expiresOn.Sub(time.Now()) < 0 {
+	if time.Until(sess.expiresOn) < 0 {
 		log.Printf("Session expired on %s, but it is %s now.", sess.expiresOn, time.Now())
-		return errors.New("Session expired")
+		return errors.New("session expired")
 	}
 	err := securecookie.DecodeMulti(session.Name(), sess.data, &session.Values, m.Codecs...)
 	if err != nil {

--- a/sqlitestore.go
+++ b/sqlitestore.go
@@ -281,3 +281,11 @@ func (m *SqliteStore) load(session *sessions.Session) error {
 	return nil
 
 }
+
+func (m *SqliteStore) MaxLength(l int) {
+	for _, c := range m.Codecs {
+		if codec, ok := c.(*securecookie.SecureCookie); ok {
+			codec.MaxLength(l)
+		}
+	}
+}


### PR DESCRIPTION
Hi,

Thanks for writing `sqlitestore`.

I had been hitting this issue while using openid-connect`as a provider with goth: https://github.com/markbates/goth/issues/133

The solution is to increase the size of `SecureCookie`s, which default to 4096. To do this with `sqlitestore`, I've added a new `MaxLength` method. This is basically a copy from `github.com/gorilla/sessions`'s `FilesystemStore`'s `MaxLength`: https://github.com/gorilla/sessions/blob/466d29e7f343560836292b7c922e1385e908ef95/store.go#L173

Staticcheck was showing a couple of warnings, so I also fixed them.

Thanks,
Mark